### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LAB_01_prepare_azure_environment.md
+++ b/Instructions/Labs/LAB_01_prepare_azure_environment.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Prepare your Azure environment'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Prepare your Azure environment
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll prepare the environment for the guided project.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Azure
 ---
+
 In this exercise, you’ll prepare the environment for the guided project.
 
 This exercise should take approximately **30** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md
+++ b/Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Exercise - Deploy Log Analytics'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Deploy Log Analytics
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll configure log analytics for Azure Monitor.
+  duration: 10 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Monitor
 ---
+
 In this exercise, you’ll configure log analytics for Azure Monitor.
 
 This exercise should take approximately **10** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_03_exercise_monitor_web_apps.md
+++ b/Instructions/Labs/LAB_03_exercise_monitor_web_apps.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Exercise - Monitor web apps'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Monitor web apps
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll prepare configure Azure Monitor for web apps.
+  duration: 20 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Monitor
 ---
+
 In this exercise, you’ll prepare configure Azure Monitor for web apps.
 
 This exercise should take approximately **20** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md
+++ b/Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Exercise - Configure monitoring for compute services'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Configure monitoring for compute services
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll configure monitoring for compute services.
+  duration: 15 minutes
+  level: 300
+  islab: true
 ---
+
 In this exercise, you’ll configure monitoring for compute services.
 
 This exercise should take approximately **15** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_05_exercise_configure_alerts.md
+++ b/Instructions/Labs/LAB_05_exercise_configure_alerts.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Exercise - Configure alerts'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Configure alerts
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll configure alerts and actions.
+  duration: 10 minutes
+  level: 200
+  islab: true
 ---
+
 In this exercise, you’ll configure alerts and actions.
 
 This exercise should take approximately **10** minutes to complete. <!-- update with estimated duration -->


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LAB_01_prepare_azure_environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_03_exercise_monitor_web_apps.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_05_exercise_configure_alerts.md` (description,duration,level,islab)
