### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/LAB_01_prepare_azure_environment.md
+++ b/Instructions/Labs/LAB_01_prepare_azure_environment.md
@@ -2,12 +2,17 @@
 lab:
   title: Prepare your Azure environment
   module: Guided Project - Deploy and configure Azure Monitor
-  description: In this exercise, you create an Entra ID security group.
+  description: You prepare the Azure environment for a monitoring-focused guided project. You provision a resource group, security group, Windows and Linux virtual machines, and a web app with SQL database.
   duration: 30 minutes
   level: 300
   islab: true
   primarytopics:
-    - Azure
+    - Resource Groups
+    - Microsoft Entra ID
+    - Virtual Machines
+    - App Service
+    - Azure SQL Database
+    - ARM Templates
 ---
 
 In this exercise, you’ll prepare the environment for the guided project.

--- a/Instructions/Labs/LAB_01_prepare_azure_environment.md
+++ b/Instructions/Labs/LAB_01_prepare_azure_environment.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Prepare your Azure environment'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Prepare your Azure environment
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you create an Entra ID security group.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
+
 In this exercise, you’ll prepare the environment for the guided project.
 
 This exercise should take approximately **30** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md
+++ b/Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md
@@ -2,13 +2,17 @@
 lab:
   title: Exercise - Deploy Log Analytics
   module: Guided Project - Deploy and configure Azure Monitor
-  description: In this exercise, you’ll configure log analytics for Azure Monitor.
+  description: You deploy a Log Analytics workspace and configure the Azure Monitor Agent on a Linux virtual machine using a data collection rule. You verify data ingestion with KQL queries and configure workspace access using role-based access control.
   duration: 10 minutes
-  level: 400
+  level: 300
   islab: true
   primarytopics:
-    - Azure
     - Azure Monitor
+    - Log Analytics
+    - Data Collection Rules
+    - Azure Monitor Agent
+    - KQL
+    - Role-Based Access Control
 ---
 
 In this exercise, you’ll configure log analytics for Azure Monitor.

--- a/Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md
+++ b/Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Exercise - Deploy Log Analytics'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Deploy Log Analytics
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll configure log analytics for Azure Monitor.
+  duration: 10 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Monitor
 ---
+
 In this exercise, you’ll configure log analytics for Azure Monitor.
 
 This exercise should take approximately **10** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_03_exercise_monitor_web_apps.md
+++ b/Instructions/Labs/LAB_03_exercise_monitor_web_apps.md
@@ -2,13 +2,16 @@
 lab:
   title: Exercise - Monitor web apps
   module: Guided Project - Deploy and configure Azure Monitor
-  description: In this exercise, you’ll prepare configure Azure Monitor for web apps.
+  description: You configure Azure Monitor for web applications hosted in App Service. You enable Application Insights, route HTTP and SQL diagnostic logs to a Log Analytics workspace, and enable file and configuration change tracking.
   duration: 20 minutes
   level: 300
   islab: true
   primarytopics:
-    - Azure
     - Azure Monitor
+    - Application Insights
+    - App Service
+    - Diagnostic Settings
+    - SQL Insights
 ---
 
 In this exercise, you’ll prepare configure Azure Monitor for web apps.

--- a/Instructions/Labs/LAB_03_exercise_monitor_web_apps.md
+++ b/Instructions/Labs/LAB_03_exercise_monitor_web_apps.md
@@ -1,8 +1,16 @@
 ---
 lab:
-    title: 'Exercise - Monitor web apps'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Monitor web apps
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll prepare configure Azure Monitor for web apps.
+  duration: 20 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Monitor
 ---
+
 In this exercise, you’ll prepare configure Azure Monitor for web apps.
 
 This exercise should take approximately **20** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md
+++ b/Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Exercise - Configure monitoring for compute services'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Configure monitoring for compute services
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll configure monitoring for compute services.
+  duration: 15 minutes
+  level: 300
+  islab: true
 ---
+
 In this exercise, you’ll configure monitoring for compute services.
 
 This exercise should take approximately **15** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md
+++ b/Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md
@@ -2,10 +2,17 @@
 lab:
   title: Exercise - Configure monitoring for compute services
   module: Guided Project - Deploy and configure Azure Monitor
-  description: In this exercise, you’ll configure monitoring for compute services.
+  description: You configure Azure Monitor for compute services by creating a data collection endpoint and data collection rule for a Windows virtual machine. You add IIS log collection to an existing rule and configure Network Connection Monitor for a Linux virtual machine.
   duration: 15 minutes
   level: 300
   islab: true
+  primarytopics:
+    - Azure Monitor
+    - Data Collection Rules
+    - Data Collection Endpoints
+    - IIS Logs
+    - Network Connection Monitor
+    - Network Watcher
 ---
 
 In this exercise, you’ll configure monitoring for compute services.

--- a/Instructions/Labs/LAB_05_exercise_configure_alerts.md
+++ b/Instructions/Labs/LAB_05_exercise_configure_alerts.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Exercise - Configure alerts'
-    module: 'Guided Project - Deploy and configure Azure Monitor'
+  title: Exercise - Configure alerts
+  module: Guided Project - Deploy and configure Azure Monitor
+  description: In this exercise, you’ll configure alerts and actions.
+  duration: 10 minutes
+  level: 200
+  islab: true
 ---
+
 In this exercise, you’ll configure alerts and actions.
 
 This exercise should take approximately **10** minutes to complete. <!-- update with estimated duration -->

--- a/Instructions/Labs/LAB_05_exercise_configure_alerts.md
+++ b/Instructions/Labs/LAB_05_exercise_configure_alerts.md
@@ -2,10 +2,15 @@
 lab:
   title: Exercise - Configure alerts
   module: Guided Project - Deploy and configure Azure Monitor
-  description: In this exercise, you’ll configure alerts and actions.
+  description: You configure alerts and notifications in Azure Monitor. You create an email action group and define a CPU utilization alert rule for a virtual machine.
   duration: 10 minutes
   level: 200
   islab: true
+  primarytopics:
+    - Azure Monitor
+    - Alerts
+    - Action Groups
+    - Virtual Machines
 ---
 
 In this exercise, you’ll configure alerts and actions.


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/LAB_01_prepare_azure_environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_02_exercise_deploy_log_analytics.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_03_exercise_monitor_web_apps.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/LAB_04_exercise_configure_monitoring_compute_services.md` (description,duration,level,islab)
- `Instructions/Labs/LAB_05_exercise_configure_alerts.md` (description,duration,level,islab)
